### PR TITLE
Strip binary of debug info.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: test build
 
 .PHONY: build
 build: ## Build the project
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) $(GOBUILD) -ldflags "-X github.com/gomicro/probe/cmd.Version=$(BUILD_VERSION)" -o $(APP) .
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) $(GOBUILD) -ldflags "-X github.com/gomicro/probe/cmd.Version=$(BUILD_VERSION) -s -w" -o $(APP) .
 
 .PHONY: clean
 clean: ## Clean out all generated files


### PR DESCRIPTION
Strips debug info from binary. Reduces size from 12 MB to 9.1 MB on my Macbook.

Ref: https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/ and https://golang.org/cmd/link/ .