### PR TITLE
Use Go 1.15 for building on GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Setup
       run: |
@@ -47,7 +47,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ See the [Latest Release](https://github.com/gomicro/probe/releases/latest) page 
 
 ## From Source
 
-Requires Golang version 1.14 or higher
-
 ```
 go get -u github.com/gomicro/probe
 go install github.com/gomicro/probe


### PR DESCRIPTION
Go 1.13 is no longer supported. Switches to Go 1.15.

Question: should the README's minimum Go version be updated since this change no longer tests on anything before Go 1.15?