### PR TITLE
Strip binary of debug info for release.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
 
   ldflags:
     - -X "github.com/gomicro/probe/cmd.Version={{.Env.VERSION}}"
+    - "-s -w"
 
   goos:
     - darwin


### PR DESCRIPTION
Tested locally with `VERSION=a goreleaser build --skip-validate --rm-dist`.

Before:

```bash
» ls -lh dist/probe_linux_amd64 
total 23576
-rwxr-xr-x  1 matthew  staff    12M Oct 27 11:46 probe
```

After:

```bash
» ls -lh dist/probe_linux_amd64                       
total 16952
-rwxr-xr-x  1 matthew  staff   8.3M Oct 27 11:47 probe
```